### PR TITLE
Add loop to task attributes

### DIFF
--- a/examples/loop.rh
+++ b/examples/loop.rh
@@ -1,0 +1,14 @@
+#!/usr/bin/env -S rash -eMY_PASSWORD=supersecret
+
+- name: "save password to {{ item }} file"
+  copy:
+    content: "{{ env.MY_PASSWORD }}"
+    dest: "/tmp/{{ item }}_MY_PASSWORD_FILE"
+    mode: "400"
+  loop: "{{ range(end=4) }}"
+
+- command: echo "{{ item }}"
+  loop:
+    - 1
+    - 2
+    - "{{ env.MY_PASSWORD }}"

--- a/rash_core/src/modules/mod.rs
+++ b/rash_core/src/modules/mod.rs
@@ -13,7 +13,7 @@ use yaml_rust::Yaml;
 /// Return values by [`Module`] execution.
 ///
 /// [`Module`]: struct.Module.html
-#[derive(PartialEq, Debug)]
+#[derive(Debug, PartialEq)]
 pub struct ModuleResult {
     changed: bool,
     extra: Option<Value>,

--- a/rash_core/src/utils/mod.rs
+++ b/rash_core/src/utils/mod.rs
@@ -2,6 +2,8 @@ pub mod file;
 
 use crate::error::{Error, ErrorKind, Result};
 
+use yaml_rust::{Yaml, YamlLoader};
+
 pub fn parse_octal(s: &str) -> Result<u32> {
     match s.len() {
         3 => u32::from_str_radix(&s, 8).or_else(|e| Err(Error::new(ErrorKind::InvalidData, e))),
@@ -14,13 +16,10 @@ pub fn parse_octal(s: &str) -> Result<u32> {
     }
 }
 
-#[cfg(test)]
-use yaml_rust::{Yaml, YamlLoader};
-
-#[cfg(test)]
-pub fn get_yaml(s: String) -> Yaml {
-    let doc = YamlLoader::load_from_str(&s).unwrap();
-    doc.first().unwrap().clone()
+pub fn get_yaml(s: &str) -> Result<Yaml> {
+    let doc =
+        YamlLoader::load_from_str(&s).or_else(|e| Err(Error::new(ErrorKind::InvalidData, e)))?;
+    Ok(doc.first().unwrap().clone())
 }
 
 #[cfg(test)]
@@ -35,5 +34,11 @@ mod tests {
         assert_eq!(parse_octal("0444").unwrap(), 0o444);
         assert_eq!(parse_octal("600").unwrap(), 0o600);
         assert_eq!(parse_octal("0600").unwrap(), 0o600);
+    }
+
+    #[test]
+    fn test_get_yaml() {
+        let yaml = get_yaml(&"foo: boo").unwrap();
+        assert_eq!(yaml["foo"].as_str().unwrap(), "boo")
     }
 }

--- a/rash_core/tests/rash_derive.rs
+++ b/rash_core/tests/rash_derive.rs
@@ -8,13 +8,14 @@ mod tests {
     struct Test {
         foo: bool,
         boo: u8,
+        r#loop: u16,
     }
 
     #[test]
     fn test_fieldnames() {
         assert_eq![
             Test::get_field_names(),
-            ["foo", "boo"]
+            ["foo", "boo", "loop"]
                 .iter()
                 .map(ToString::to_string)
                 .collect::<HashSet<String>>()

--- a/rash_derive/src/lib.rs
+++ b/rash_derive/src/lib.rs
@@ -30,7 +30,7 @@ pub fn derive_field_names(input: TokenStream) -> TokenStream {
         impl #name {
             /// Return field names.
             pub fn get_field_names() -> std::collections::HashSet<String> {
-                [#(#field_names),*].iter().map(ToString::to_string).collect::<std::collections::HashSet<String>>()
+                [#(#field_names),*].iter().map(ToString::to_string).map(|s| s.replace("r#", "")).collect::<std::collections::HashSet<String>>()
             }
         }
     };


### PR DESCRIPTION
- `get_yaml` is now a public function not just for testing.
- add functions to operate with loop interators and renders at tasks.
- fix rash_derive to support `r#loop` sintax to use protected words as
  fields.

Resolves: #8