### PR TITLE
[module][command] Fix: execute cmd with sh

### DIFF
--- a/examples/env.rh
+++ b/examples/env.rh
@@ -1,4 +1,4 @@
 #!/usr/bin/env -S rash -eTARGET=rash_core -eTITTLE="list rash_core dir"
 
 - name: "{{ env.TITTLE }}"
-  command: ls {{ env.TARGET }}
+  command: ls $TARGET

--- a/examples/env_missing.rh
+++ b/examples/env_missing.rh
@@ -1,5 +1,5 @@
 #!/bin/rash
 
 - name: "{{ env.TITTLE }}"
-  command: ls {{ env.target }}
+  command: ls $TARGET
   when: env | get(key="TARGET")

--- a/examples/env_name_missing.rh
+++ b/examples/env_name_missing.rh
@@ -1,4 +1,4 @@
 #!/usr/bin/env -S rash -eTARGET=rash_core
 
 - name: "{{ env.TITTLE }}"
-  command: ls {{ env.TARGET }}
+  command: ls $TARGET

--- a/rash_core/src/modules/command.rs
+++ b/rash_core/src/modules/command.rs
@@ -38,20 +38,19 @@ pub fn exec(optional_params: Yaml, vars: Vars) -> Result<(ModuleResult, Vars)> {
     let params = parse_params(optional_params)?;
     trace!("exec - params: {:?}", params);
 
-    let mut args = params.cmd.split_whitespace();
-
-    // safe unwrap: verify in parse_params
-    let program = args.next().unwrap();
-
     if params.transfer_pid_1 {
+        let mut args = params.cmd.split_whitespace();
+
+        // safe unwrap: verify in parse_params
+        let program = args.next().unwrap();
         let error = exec_command::Command::new(program)
             .args(&args.clone().collect::<Vec<_>>())
             .exec();
         return Err(Error::new(ErrorKind::SubprocessFail, error));
     }
 
-    let output = Command::new(program)
-        .args(&args.collect::<Vec<_>>())
+    let output = Command::new("/bin/sh")
+        .args(vec!["-c", &params.cmd])
         .output()
         .or_else(|e| Err(Error::new(ErrorKind::SubprocessFail, e)))?;
 


### PR DESCRIPTION
Pass cmd as full argument without spliting to a shell. This allows to
render environment vars at shell and avoid unexpected behaviour about
parsing command lines (old split whitespace).